### PR TITLE
[1.12.2 branch needed] Fixed maze reward removing gravestones from other mods

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,5 +10,5 @@ If you would like to contribute, simply fork the repository and make sure you ha
 **Note for Contributors:** Support for older versions of Minecraft is not guaranteed and contributions to the corresponding branches will almost certainly be denied for this reason, the sole exception being game-breaking bugs which are usually squashed by the time support ends.
 
 **Currently supported branches:**\
-dev_1.12.1\
+dev_1.12.2\
 dev_1.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-mc_version=1.12.1
-forge_version=14.22.0.2467
+mc_version=1.12.2
+forge_version=14.23.1.2562
 
 mod_version=3.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip

--- a/src/main/java/chanceCubes/CCubesCore.java
+++ b/src/main/java/chanceCubes/CCubesCore.java
@@ -43,7 +43,7 @@ public class CCubesCore
 	public static final String VERSION = "@VERSION@";
 	public static final String NAME = "Chance Cubes";
 
-	public static final String gameVersion = "1.12.1";
+	public static final String gameVersion = "1.12.2";
 
 	@Instance(value = MODID)
 	public static CCubesCore instance;

--- a/src/main/java/chanceCubes/rewards/defaultRewards/MazeReward.java
+++ b/src/main/java/chanceCubes/rewards/defaultRewards/MazeReward.java
@@ -33,9 +33,9 @@ public class MazeReward implements IChanceCubeReward
 			public void callback()
 			{
 				player.setPositionAndUpdate(px, py, pz);
+				gen.endMaze(world);
 				if(RewardsUtil.isPlayerOnline(player))
 					player.attackEntityFrom(CCubesDamageSource.MAZE_FAIL, Float.MAX_VALUE);
-				gen.endMaze(world);
 			}
 
 			@Override

--- a/src/main/java/chanceCubes/util/MazeGenerator.java
+++ b/src/main/java/chanceCubes/util/MazeGenerator.java
@@ -1,5 +1,10 @@
 package chanceCubes.util;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
 import net.minecraft.block.BlockTorch;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -10,11 +15,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
 
 public class MazeGenerator
 {
@@ -36,7 +36,7 @@ public class MazeGenerator
 	public BlockPos endBlockWorldCords;
 
 	/**
-	 * 
+	 *
 	 * @param multiple
 	 * @param x1
 	 * @param y1

--- a/src/main/java/chanceCubes/util/MazeGenerator.java
+++ b/src/main/java/chanceCubes/util/MazeGenerator.java
@@ -1,10 +1,5 @@
 package chanceCubes.util;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-
 import net.minecraft.block.BlockTorch;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -15,6 +10,11 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
 
 public class MazeGenerator
 {


### PR DESCRIPTION
So currently, the Maze reward overrides any gravestones spawned by gravestone / tomestone mods when the reward removes the maze, which causes players to lose their items and they have to restore from backup / cheat items back in. This is a simple fix for that by removing the Maze first before killing the player, so the gravestones can spawn in properly.

I bumped version to 1.12.2 as the Forge recommended build is on 1.12.2, so a `dev_1.12.2` branch is needed for this PR. I'll change the target branch when the 1.12.2 branch is created. Also updated Gradle to latest version.

Also, it might be a better idea to change the repo's default branch to 1.12.2 as well, it's always better to have the latest version as the default branch.