### PR TITLE
Fix instantly broken rewards

### DIFF
--- a/src/main/java/chanceCubes/blocks/BlockChanceCube.java
+++ b/src/main/java/chanceCubes/blocks/BlockChanceCube.java
@@ -8,6 +8,7 @@ import chanceCubes.util.GiantCubeUtil;
 import chanceCubes.util.StatsRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.stats.Stats;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
@@ -57,13 +58,17 @@ public class BlockChanceCube extends BaseChanceBlock implements EntityBlock
 				level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
 				level.removeBlockEntity(pos);
 				level.addFreshEntity(blockStack);
+				player.awardStat(Stats.BLOCK_MINED.get(this));
 				return;
 			}
 
 			level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
 			GlobalCCRewardRegistry.DEFAULT.triggerRandomReward((ServerLevel) level, pos, player, te.getChance());
 			player.awardStat(StatsRegistry.OPENED_CHANCE_CUBE);
+			return;
 		}
+
+		super.playerDestroy(level, player, pos, state, be, stack);
 	}
 
 	@Override

--- a/src/main/java/chanceCubes/blocks/BlockChanceCube.java
+++ b/src/main/java/chanceCubes/blocks/BlockChanceCube.java
@@ -43,16 +43,16 @@ public class BlockChanceCube extends BaseChanceBlock implements EntityBlock
 	}
 
 	@Override
-	public void playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player)
+	public void playerDestroy(Level level, Player player, BlockPos pos, BlockState state, BlockEntity be, ItemStack stack)
 	{
-		super.playerWillDestroy(level, pos, state, player);
-		BlockEntity be = level.getBlockEntity(pos);
 		if(!level.isClientSide() && !(player instanceof FakePlayer) && be instanceof TileChanceCube te)
 		{
 			if(!player.getInventory().getSelected().isEmpty() && player.getInventory().getSelected().getItem().equals(CCubesItems.silkPendant))
 			{
 				ItemStack stackCube = new ItemStack(CCubesItems.CHANCE_CUBE, 1);
-				((ItemChanceCube) stackCube.getItem()).setChance(stackCube, te.isScanned() ? te.getChance() : -101);
+				if (te.isScanned()) {
+					((ItemChanceCube) stackCube.getItem()).setChance(stackCube, te.isScanned() ? te.getChance() : -101);
+				}
 				ItemEntity blockStack = new ItemEntity(level, pos.getX(), pos.getY(), pos.getZ(), stackCube);
 				level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
 				level.removeBlockEntity(pos);


### PR DESCRIPTION
When a ChanceCube is opened and the reward has a block in the same position as the ChanceCube that block in the reward will be instantly broken, regardless of hardness or anything.

This appears to happen because the rewards are triggered using `playerWillDestroy`, which triggers before the break event has finished meaning any blocks placed will be instantly destroyed after the event finishes. Since you can't cancel the event easily moving to `playerDestroy` and reorganizing variables seems to fix the problem.

Trojan horse: Also made it so when breaking with a Silk Touch Pendent it doesn't have NBT when the cube was never scanned, making it stack.