### PR TITLE
Allow automation of giant chance cubes by removing fakeplayer check.

### DIFF
--- a/src/main/java/chanceCubes/blocks/BlockGiantCube.java
+++ b/src/main/java/chanceCubes/blocks/BlockGiantCube.java
@@ -50,7 +50,7 @@ public class BlockGiantCube extends BaseChanceBlock implements EntityBlock
 	{
 		super.playerWillDestroy(level, pos, state, player);
 		BlockEntity be = level.getBlockEntity(pos);
-		if(!level.isClientSide() && !(player instanceof FakePlayer) && be instanceof TileGiantCube gcte)
+		if(!level.isClientSide() && be instanceof TileGiantCube gcte)
 		{
 			if(!player.getInventory().getSelected().isEmpty() && player.getInventory().getSelected().getItem().equals(CCubesItems.silkPendant))
 			{


### PR DESCRIPTION
Was playing in a modpack recently and realized that mods that allow for automated block breaking while holding items weren't able to break large chance cubes, with or without the chance pendant. Wanted to automate the production of large chance cubes for some fun, but couldn't. I don't know if this is intentional, assuming it's isn't though, this pr changes it so that they can be mined by things that act as fake players (specifically, such as create and similar mods).

It may be better to split the checks so that it only works when holding the silk touch chance pendant, not sure.